### PR TITLE
add algolia index

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,15 @@ enableRobotsTXT = true
 # Hugo allows theme composition (and inheritance). The precedence is from left to right.
 theme = ["docsy"]
 
+# [outputFormats.Algolia]
+# baseName = "algolia"
+# isPlainText = true
+# mediaType = "application/json"
+# notAlternative = true
+# 
+# [outputs]
+# home = ["HTML", "RSS", "Algolia"]
+
 # Will give values to .Lastmod etc.
 enableGitInfo = true
 


### PR DESCRIPTION
Algolia output format breaks the theme. I can't figure out a way around it so for now, if i want to update the index i need to uncomment the output formats, run `hugo && npm run algolia` to update the index, and then go back to commenting them so the theme will work.